### PR TITLE
Minor fixes for example tables

### DIFF
--- a/lib/cucumber/city_builder.rb
+++ b/lib/cucumber/city_builder.rb
@@ -132,6 +132,7 @@ module Cucumber
             end
 
             @step_container.example_values_for_row(row_index).each do |key,text|
+              text ||= "" #handle empty cells in the example table
               step_instance.value.gsub!("<#{key}>",text)
               step_instance.text.gsub!("<#{key}>",text) if step_instance.has_text?
               step_instance.table.each{|row| row.each{|col| col.gsub!("<#{key}>",text)}} if step_instance.has_table?

--- a/lib/yard/code_objects/cucumber/scenario_outline.rb
+++ b/lib/yard/code_objects/cucumber/scenario_outline.rb
@@ -29,10 +29,12 @@ module YARD::CodeObjects::Cucumber
     end
     
     def example_headers
+      return "Error - no example in a Scenario Outline - should it be a Scenario instead?" unless @examples[:rows]
       @examples[:rows].first
     end
     
     def example_data
+      return "" unless @examples[:rows]
       @examples[:rows][1..-1]
     end
 


### PR DESCRIPTION
A few crashes that I ran into when running it on our features:
- we don't always have the Example tables filled out if the feature is partially written, and 
- we also had a case of a Scenario Outline with no examples, bad syntax but now there will be an error in the docs rather than a crash of CITY with a stack trace
