### PR TITLE
Stop displaying duplicate usages of step definitions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yard-cucumber (2.3.0)
+    yard-cucumber (2.3.1)
       cucumber (~> 1.3)
       gherkin (~> 2.12)
       yard (>= 0.8.1)
@@ -10,19 +10,19 @@ GEM
   remote: https://rubygems.org/
   specs:
     builder (3.2.2)
-    cucumber (1.3.3)
+    cucumber (1.3.9)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
-      gherkin (~> 2.12.0)
-      multi_json (~> 1.7.5)
-      multi_test (~> 0.0.1)
-    diff-lcs (1.2.4)
-    gherkin (2.12.0)
+      gherkin (~> 2.12)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.0.2)
+    diff-lcs (1.2.5)
+    gherkin (2.12.2)
       multi_json (~> 1.3)
-    multi_json (1.7.7)
-    multi_test (0.0.1)
+    multi_json (1.8.2)
+    multi_test (0.0.2)
     redcarpet (2.2.2)
-    yard (0.8.6.2)
+    yard (0.8.7.3)
 
 PLATFORMS
   ruby

--- a/lib/yard/code_objects/cucumber/step.rb
+++ b/lib/yard/code_objects/cucumber/step.rb
@@ -3,16 +3,16 @@
 module YARD::CodeObjects::Cucumber
 
   class Step < Base
-    
+
     attr_accessor :comments, :definition, :examples, :keyword, :scenario, :table, :text, :transforms, :value
-    
+
     def initialize(namespace,name)
       super(namespace,name.to_s.strip)
       @comments = @definition = @description = @keyword = @table = @text = @value = nil
       @examples = {}
       @transforms = []
     end
-    
+
     def has_table?
       !@table.nil?
     end
@@ -20,12 +20,15 @@ module YARD::CodeObjects::Cucumber
     def has_text?
       !@text.nil?
     end
-    
+
     def definition=(stepdef)
       @definition = stepdef
-      stepdef.steps << self
+
+      unless stepdef.steps.map(&:files).include?(files)
+        stepdef.steps << self
+      end
     end
-    
+
     def transformed?
       !@transforms.empty?
     end


### PR DESCRIPTION
Prior to this patch when you use a Example table in cucumber each row would be displayed as a separate usage of the step.

**Before**:
![](http://i.imgur.com/PW1ySPD.png)

**After**:
![](http://i.imgur.com/HDQG0ug.png)
