### PR TITLE
Add ability to collapse individual step definition

### DIFF
--- a/lib/cucumber/city_builder.rb
+++ b/lib/cucumber/city_builder.rb
@@ -58,7 +58,7 @@ module Cucumber
       end
 
       #
-      # Find the tag if it exists within the YARD Registry, if it doesn' t then
+      # Find the tag if it exists within the YARD Registry, if it doesn't then
       # create it.
       #
       # We note that the tag was used in this file at the current line.

--- a/lib/docserver/default/layout/html/headers.erb
+++ b/lib/docserver/default/layout/html/headers.erb
@@ -7,7 +7,6 @@
 <script type="text/javascript" charset="utf-8" src="/js/jquery.js"></script>
 <script type="text/javascript" charset="utf-8" src="/js/autocomplete.js"></script>
 <script type="text/javascript" charset="utf-8" src="/js/app.js"></script>
-<script type="text/javascript" charset="utf-8" src="/js/live.js"></script>
 <script type="text/javascript" charset="utf-8" src="/js/cucumber.js"></script>
 <script type="text/javascript" charset="utf-8">
   library = '<%= base_path(router.list_prefix) %>';

--- a/lib/templates/default/fulldoc/html/js/cucumber.js
+++ b/lib/templates/default/fulldoc/html/js/cucumber.js
@@ -81,9 +81,28 @@ $(function() {
                 $('div.' + eventObject.currentTarget.id + ' > div.details:hidden').each(function() {
                     $(this).show(200);
                 });
+                $('div.' + eventObject.currentTarget.id + ' a.stepdef').text("[Collapse]")
             } else {
                 eventObject.currentTarget.innerHTML = '[Expand All]';
                 $('div.' + eventObject.currentTarget.id + ' > div.details:visible').each(function() {
+                    $(this).hide(200);
+                });
+                console.log(eventObject.currentTarget.id);
+                $('div.' + eventObject.currentTarget.id + ' a.stepdef').text('[Expand]');
+            }
+        }
+    });
+
+    $('.stepdef').click(function(eventObject) {
+        if (typeof eventObject.currentTarget !== "undefined") {
+            if (eventObject.currentTarget.innerHTML === '[Expand]') {
+                eventObject.currentTarget.innerHTML = '[Collapse]';
+                $(eventObject.target).parent().parent().parent().find("div.details:hidden").each(function() {
+                    $(this).show(200);
+                });
+            } else {
+                eventObject.currentTarget.innerHTML = '[Expand]';
+                $(eventObject.target).parent().parent().parent().find("div.details:visible").each(function() {
                     $(this).hide(200);
                 });
             }

--- a/lib/templates/default/steptransformers/html/transformers.erb
+++ b/lib/templates/default/steptransformers/html/transformers.erb
@@ -11,6 +11,7 @@
       <a href="http://rubular.com/?regex=<%= urlencode item.value %>" target="_blank">Rubular</a>
       <%= "| PENDING" if item.pending %>
       <%= "| UNUSED" if item.steps.nil? || item.steps.empty? %>
+      <a class="stepdef" href="#">[Collapse]</a>
     </div>
     <div style="clear: both;"></div>
   </div>


### PR DESCRIPTION
Fixed a typo on the side, as well as removed a script that is no longer in Yard. The rest of the changes add the ability to collapse and expand individual Step Definitions.