### PR TITLE
cucumber 2.0 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     yard-cucumber (2.3.2)
-      cucumber (~> 1.3)
+      cucumber (>= 1.3.0)
       gherkin (~> 2.12)
       yard (>= 0.8.1)
 
@@ -10,23 +10,28 @@ GEM
   remote: https://rubygems.org/
   specs:
     builder (3.2.2)
-    cucumber (1.3.10)
+    cucumber (2.0.2)
       builder (>= 2.1.2)
+      cucumber-core (~> 1.2.0)
       diff-lcs (>= 1.1.3)
       gherkin (~> 2.12)
       multi_json (>= 1.7.5, < 2.0)
-      multi_test (>= 0.0.2)
+      multi_test (>= 0.1.2)
+    cucumber-core (1.2.0)
+      gherkin (~> 2.12.0)
     diff-lcs (1.2.5)
     gherkin (2.12.2)
       multi_json (~> 1.3)
-    multi_json (1.8.2)
-    multi_test (0.0.2)
+    multi_json (1.11.2)
+    multi_test (0.1.2)
+    rake (10.4.2)
     redcarpet (2.2.2)
-    yard (0.8.7.3)
+    yard (0.8.7.6)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  rake
   redcarpet
   yard-cucumber!

--- a/lib/yard-cucumber.rb
+++ b/lib/yard-cucumber.rb
@@ -1,5 +1,4 @@
 require 'cucumber/platform'
-require 'cucumber/parser/gherkin_builder'
 require 'gherkin/parser/parser'
 require 'gherkin/formatter/tag_count_formatter'
 

--- a/yard-cucumber.gemspec
+++ b/yard-cucumber.gemspec
@@ -54,8 +54,10 @@ Gem::Specification.new do |s|
 
 }
 
+  s.add_development_dependency 'rake'
+
   s.add_dependency 'gherkin', '~> 2.12'
-  s.add_dependency 'cucumber', '~> 1.3'
+  s.add_dependency 'cucumber', '>= 1.3.0'
   s.add_dependency 'yard', '>= 0.8.1'
 
   s.rubygems_version   = "1.3.7"


### PR DESCRIPTION
fixes #60 I think (seems to work with the example as well as it did before - I got and still get some parse errors from the readmes)

Wasn't sure what to do with the dependency version as `~>1.3` isn't quite right now so I made it `>=1.3.0` but that seems a bit open ended