### PR TITLE
Bump up to gherkin 4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
 gem 'redcarpet'
-gem 'gherkin', '~> 3'
+gem 'gherkin', '~> 4.0'
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,37 +1,42 @@
 PATH
   remote: .
   specs:
-    yard-cucumber (2.3.2)
-      cucumber (>= 1.3.0)
-      gherkin (~> 2.12)
-      yard (>= 0.8.1)
+    yard-cucumber (3.0.0)
+      cucumber (~> 2)
+      gherkin (~> 4.0)
+      yard (~> 0.8, >= 0.8.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     builder (3.2.2)
-    cucumber (2.0.2)
+    cucumber (2.4.0)
       builder (>= 2.1.2)
-      cucumber-core (~> 1.2.0)
+      cucumber-core (~> 1.5.0)
+      cucumber-wire (~> 0.0.1)
       diff-lcs (>= 1.1.3)
-      gherkin (~> 2.12)
+      gherkin (~> 4.0)
       multi_json (>= 1.7.5, < 2.0)
       multi_test (>= 0.1.2)
-    cucumber-core (1.2.0)
-      gherkin (~> 2.12.0)
+    cucumber-core (1.5.0)
+      gherkin (~> 4.0)
+    cucumber-wire (0.0.1)
     diff-lcs (1.2.5)
-    gherkin (2.12.2)
-      multi_json (~> 1.3)
-    multi_json (1.11.2)
+    gherkin (4.0.0)
+    multi_json (1.12.1)
     multi_test (0.1.2)
     rake (10.4.2)
     redcarpet (2.2.2)
-    yard (0.8.7.6)
+    yard (0.9.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  rake
+  gherkin (~> 4.0)
+  rake (~> 10)
   redcarpet
   yard-cucumber!
+
+BUNDLED WITH
+   1.12.4

--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ English step definitions. Even without specifying this feature files in other
 languages are found, this provides the ability for the step definitions to match
 correctly to step definitions.
 
+* Exclude features or scenarios from yardoc
+
+You can exclude any feature or scenario from the yardoc by adding a predefined tags to them.
+To define tags that will be excluded, again in yard configuration file:
+
+```yaml
+:"yard-cucumber":
+  exclude_tags: [ 'exclude-yardoc', 'also-exclude-yardoc' ]
+```
+
 ## Details
 
 There are two things that I enjoy: a test framework written in my own Domain

--- a/lib/cucumber/city_builder.rb
+++ b/lib/cucumber/city_builder.rb
@@ -87,9 +87,9 @@ module Cucumber
       # This is once, as the gherking parser does not like multiple feature per
       # file.
       #
-      def feature(feature)
+      def feature(document)
         #log.debug "FEATURE"
-
+        feature = document[:feature]
         return if has_exclude_tags?(feature[:tags].map { |t| t[:name].gsub(/^@/, '') })
 
         @feature = YARD::CodeObjects::Cucumber::Feature.new(@namespace,File.basename(@file.gsub('.feature','').gsub('.','_'))) do |f|
@@ -102,9 +102,10 @@ module Cucumber
 
           feature[:tags].each {|feature_tag| find_or_create_tag(feature_tag[:name],f) }
         end
-        background(feature[:background]) if feature[:background]
-        feature[:scenarioDefinitions].each { |s|
+        feature[:children].each { |s|
           case s[:type]
+            when :Background
+              background(s)
             when :ScenarioOutline
               scenario_outline(s)
             when :Scenario

--- a/lib/cucumber/city_builder.rb
+++ b/lib/cucumber/city_builder.rb
@@ -90,6 +90,8 @@ module Cucumber
       def feature(feature)
         #log.debug "FEATURE"
 
+        return if has_exclude_tags?(feature[:tags].map { |t| t[:name].gsub(/^@/, '') })
+
         @feature = YARD::CodeObjects::Cucumber::Feature.new(@namespace,File.basename(@file.gsub('.feature','').gsub('.','_'))) do |f|
           f.comments = feature[:comments] ? feature[:comments].map{|comment| comment[:text]}.join("\n") : ''
           f.description = feature[:description] || ''
@@ -150,6 +152,8 @@ module Cucumber
       def scenario(statement)
         #log.debug "SCENARIO"
 
+        return if has_exclude_tags?(statement[:tags].map { |t| t[:name].gsub(/^@/, '') })
+
         scenario = YARD::CodeObjects::Cucumber::Scenario.new(@feature,"scenario_#{@feature.scenarios.length + 1}") do |s|
           s.comments = statement[:comments] ? statement[:comments].map{|comment| comment.value}.join("\n") : ''
           s.description = statement[:description] || ''
@@ -177,6 +181,8 @@ module Cucumber
       #
       def scenario_outline(statement)
         #log.debug "SCENARIO OUTLINE"
+
+        return if has_exclude_tags?(statement[:tags].map { |t| t[:name].gsub(/^@/, '') })
 
         outline = YARD::CodeObjects::Cucumber::ScenarioOutline.new(@feature,"scenario_#{@feature.scenarios.length + 1}") do |s|
           s.comments = statement[:comments] ? statement[:comments].map{|comment| comment.value}.join("\n") : ''
@@ -342,6 +348,12 @@ module Cucumber
 
       def clone_table(base)
         base.map {|row| row.map {|cell| cell.dup }}
+      end
+
+      def has_exclude_tags?(tags)
+        if YARD::Config.options["yard-cucumber"] and YARD::Config.options["yard-cucumber"]["exclude_tags"]
+          return true unless (YARD::Config.options["yard-cucumber"]["exclude_tags"] & tags).empty?
+        end
       end
 
     end

--- a/lib/cucumber/city_builder.rb
+++ b/lib/cucumber/city_builder.rb
@@ -92,7 +92,7 @@ module Cucumber
 
         @feature = YARD::CodeObjects::Cucumber::Feature.new(@namespace,File.basename(@file.gsub('.feature','').gsub('.','_'))) do |f|
           f.comments = feature[:comments] ? feature[:comments].map{|comment| comment[:text]}.join("\n") : ''
-          f.description = ''#feature.description
+          f.description = feature[:description] || ''
           f.add_file(@file,feature[:location][:line])
           f.keyword = feature[:keyword]
           f.value = feature[:name]
@@ -119,7 +119,7 @@ module Cucumber
 
         @background = YARD::CodeObjects::Cucumber::Scenario.new(@feature,"background") do |b|
           b.comments = background.comments.map{|comment| comment.value}.join("\n")
-          b.description = background.description
+          b.description = background[:description] || ''
           b.keyword = background.keyword
           b.value = background.name
           b.add_file(@file,background.line)
@@ -148,7 +148,7 @@ module Cucumber
 
         scenario = YARD::CodeObjects::Cucumber::Scenario.new(@feature,"scenario_#{@feature.scenarios.length + 1}") do |s|
           s.comments = statement[:comments] ? statement[:comments].map{|comment| comment.value}.join("\n") : ''
-          s.description = ''#statement.description
+          s.description = statement[:description] || ''
           s.add_file(@file,statement[:location][:line])
           s.keyword = statement[:keyword]
           s.value = statement[:name]
@@ -176,7 +176,7 @@ module Cucumber
 
         outline = YARD::CodeObjects::Cucumber::ScenarioOutline.new(@feature,"scenario_#{@feature.scenarios.length + 1}") do |s|
           s.comments = statement[:comments] ? statement[:comments].map{|comment| comment.value}.join("\n") : ''
-          s.description = ''#statement.description
+          s.description = statement[:description] || ''
           s.add_file(@file,statement[:location][:line])
           s.keyword = statement[:keyword]
           s.value = statement[:name]

--- a/lib/cucumber/city_builder.rb
+++ b/lib/cucumber/city_builder.rb
@@ -100,6 +100,7 @@ module Cucumber
 
           feature[:tags].each {|feature_tag| find_or_create_tag(feature_tag[:name],f) }
         end
+        background(feature[:background]) if feature[:background]
         feature[:scenarioDefinitions].each { |s|
           case s[:type]
             when :ScenarioOutline
@@ -113,21 +114,24 @@ module Cucumber
       #
       # Called when a background has been found
       #
-      # @see #scenario
+      # @see #feature
       def background(background)
         #log.debug "BACKGROUND"
 
         @background = YARD::CodeObjects::Cucumber::Scenario.new(@feature,"background") do |b|
-          b.comments = background.comments.map{|comment| comment.value}.join("\n")
+          b.comments = background[:comments] ? background[:comments].map{|comment| comment.value}.join("\n") : ''
           b.description = background[:description] || ''
-          b.keyword = background.keyword
-          b.value = background.name
-          b.add_file(@file,background.line)
+          b.keyword = background[:keyword]
+          b.value = background[:name]
+          b.add_file(@file,background[:location][:line])
         end
 
         @feature.background = @background
         @background.feature = @feature
         @step_container = @background
+        background[:steps].each { |s|
+          step(s)
+        }
       end
 
       #

--- a/yard-cucumber.gemspec
+++ b/yard-cucumber.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake', '~> 10'
 
-  s.add_dependency 'gherkin', '~> 3'
+  s.add_dependency 'gherkin', '~> 4.0'
   s.add_dependency 'cucumber', '~> 2'
   s.add_dependency 'yard', '~> 0.8', '>= 0.8.1'
 


### PR DESCRIPTION
This PR includes:
1. Update gherkin version to 4.0
4.0 is a major release. Updated CityBuilder regarding major changes, gherkin change details: https://github.com/cucumber/gherkin/blob/master/CHANGELOG.md

2. Included fixes from @Kenny Gilles, to show description and background in yard

3. A tiny feature: excluding scenarios from being documented by using cucumber tags. Please, have a look to updated README for more details.
