### PR TITLE
Adding tags from scenario outline examples

### DIFF
--- a/example/scenario_outline.feature
+++ b/example/scenario_outline.feature
@@ -85,10 +85,12 @@ Feature: Displaying Scenario Outlines
     When the customer has purchased the product
     Then I expect the customer to be a member of the '<Product>' group
 
+    @groupA
     Examples: Example group A
      | Customer   | Product   |
      | Customer A | Product A |
 
+    @groupB
     Examples: Example group B
      | Customer   | Product   |
      | Customer B | Product A |

--- a/lib/cucumber/city_builder.rb
+++ b/lib/cucumber/city_builder.rb
@@ -203,7 +203,7 @@ module Cucumber
           step(s)
         }
         statement[:examples].each { |e|
-          examples(e)
+          examples(e,outline)
         }
       end
 
@@ -214,15 +214,19 @@ module Cucumber
       # later we can ensure that we have all the variations of the scenario
       # outline defined to be displayed.
       #
-      def examples(examples)
+      def examples(examples,parent)
         #log.debug "EXAMPLES"
+
+        return if has_exclude_tags?(examples[:tags].map { |t| t[:name].gsub(/^@/, '') })
 
         example = YARD::CodeObjects::Cucumber::ScenarioOutline::Examples.new(:keyword => examples[:keyword],
                                                                              :name => examples[:name],
                                                                              :line => examples[:location][:line],
                                                                              :comments => examples[:comments] ? examples.comments.map{|comment| comment.value}.join("\n") : '',
-                                                                             :rows => []
+                                                                             :rows => [],
+                                                                             :tags => examples[:tags].each {|example_tag| find_or_create_tag(example_tag[:name],parent) }
           )
+
         example.rows = [examples[:tableHeader][:cells].map{ |c| c[:value] }] if examples[:tableHeader]
         example.rows += matrix(examples[:tableBody]) if examples[:tableBody]
 

--- a/lib/yard/code_objects/cucumber/scenario_outline.rb
+++ b/lib/yard/code_objects/cucumber/scenario_outline.rb
@@ -31,7 +31,7 @@ module YARD::CodeObjects::Cucumber
     
     class Examples
       
-      attr_accessor :name, :line, :keyword, :comments, :rows
+      attr_accessor :name, :line, :keyword, :comments, :rows, :tags
       
       # The first row of the rows contains the headers for the table
       def headers


### PR DESCRIPTION
Addressing https://github.com/burtlo/yard-cucumber/issues/85

Proposed solution: Add tag to examples object and associate detected example tags with scenario outline as tag parent.