### PR TITLE
Adding example tags and scenarios counts

### DIFF
--- a/example/scenario_outline.feature
+++ b/example/scenario_outline.feature
@@ -1,4 +1,4 @@
-@scenario_outlines @bvt
+@scenario_outlines @bvt @duplicate
 Feature: Displaying Scenario Outlines
   As a reader of the documentation I expect that scenario outlines are documented correctly
 
@@ -9,6 +9,7 @@ Feature: Displaying Scenario Outlines
     When the customer has purchased the product
     Then I expect the customer to be a member of the '<Product>' group
 
+    @tagged_examples
     Examples:
      | Customer   | Product   |
      | Customer A | Product A |
@@ -61,6 +62,7 @@ Feature: Displaying Scenario Outlines
      
   # This is an example of a scenario outline in development.
   # The example table has not been defined yet
+  @fifth
   Scenario Outline: Example Table Missing
     When I click on an example row
     Then I expect <name> to be replaced by the example name
@@ -70,6 +72,7 @@ Feature: Displaying Scenario Outlines
     
   # This is an example of a scenario outline in development.  
   # The examples table has been defined, but is missing data.
+  @sixth
   Scenario Outline: Empty Example Table
     When I click on an example row
     Then I expect <name> to be replaced by the example name
@@ -79,16 +82,19 @@ Feature: Displaying Scenario Outlines
     Examples:
       | name | price | denomination |
 
+  @seventh @duplicate
   Scenario Outline: Multiple Example Table
     Given that <Customer> is a valid customer
     And that the product, named '<Product>', is a valid product
     When the customer has purchased the product
     Then I expect the customer to be a member of the '<Product>' group
 
+    @groupA @duplicate
     Examples: Example group A
      | Customer   | Product   |
      | Customer A | Product A |
 
+    @groupB
     Examples: Example group B
      | Customer   | Product   |
      | Customer B | Product A |

--- a/lib/templates/default/featuretags/html/namespace.erb
+++ b/lib/templates/default/featuretags/html/namespace.erb
@@ -1,4 +1,7 @@
 <% if @namespace %>
+  <% count = 0 %>
+  <% features.each {|f| count += f.total_scenarios } %>
+
   <div id="tags" class="requirements">
     <script type="text/javascript" charset="utf-8">
       var tag_list = [ <%= tags.collect{|t| "'#{t.value}'" }.join(',') %> ];
@@ -18,11 +21,13 @@
 
         $("#tag_search").keyup(function(evt) {
           updateTagFiltering($("#tag_search")[0].value);
+          updateScenarioCount();
         });
 
         
         $("#tag_search").keyup(function(evt) {
           updateTagFiltering($("#tag_search")[0].value);
+          updateScenarioCount();
         });
         
          $(".tag").click(function(evt) {
@@ -50,6 +55,7 @@
               
               tagSearchElement.value = (tagSearchElement.value != "" ? tagSearchElement.value + tagModifier : "") + tagToAdd;
               updateTagFiltering(tagSearchElement.value);
+              updateScenarioCount();
               
             }
         });
@@ -89,7 +95,7 @@
 
     <div id="features">
       <div class="title">
-        <span class="name">Features</span>
+        <span class="name">Features<span id="scenario_count"> (<%= count %>)</span></span>
       </div>
       <% n = 1 %>
       <ul style="padding-left: 0px;">
@@ -105,9 +111,9 @@
         <% if feature.scenarios %>
           <ul style="padding-left: 20px;">
           	<% feature.scenarios.each do |scenario| %>
-          	<li class="scenario <%= n % 2 == 0 ? 'even' : 'odd' %> <%= feature.tags.collect{|t| t.value }.join(" ") %> <%= scenario.tags.collect{|t| t.value }.join(" ") %>">
+          	<li class="scenario <%= n % 2 == 0 ? 'even' : 'odd' %> <%= feature.tags.collect{|t| t.value }.join(" ") %> <%= scenario.tags.collect{|t| t.value }.join(" ") %>" count="<%= scenario.outline? ? 0 : 1 %>">
           	  <span class='object_link'>
-             		<a href="<%= url_for(scenario.feature,"scenario#{scenario.feature.scenarios.index(scenario) }") %>">
+             		<a href="<%= url_for(scenario.feature,"scenario_#{scenario.feature.scenarios.index(scenario) }") %>">
              		  <%= h scenario.value %>
              		</a>
              	</span>
@@ -116,8 +122,30 @@
                 - <small><%= stags %></small>
               <% end %>
           	</li>
+
             <% n = n == 2 ? 1 : 2 %>
-          	<% end %>
+            
+                <% if scenario.outline? %>
+                  <ul style="padding-left: 40px;">
+                  <% scenario.examples.each do |example| %>
+                    <li class="scenario <%= n % 2 == 0 ? 'even' : 'odd' %> <%= feature.tags.collect{|t| t.value }.join(" ") %> <%= scenario.tags.collect{|t| t.value }.join(" ") %> <%= example.tags.collect{|t| t.value }.join(" ") %>" count="<%= example.data.size %>">
+
+                     <span class='object_link'>
+                       <a href="<%= url_for(scenario.feature,"scenario_#{scenario.feature.scenarios.index(scenario) }") %>">
+                          <%= example.name.nil? || example.name.empty? ? "Examples" : example.name %>
+                       </a>
+                     </span>
+
+                    <% etags = example.tags.collect{|t| tagify(t) }.join(", ") %>
+                    <% if etags && etags != "" %>
+                    - <small><%= etags %></small>
+                    <% end %>
+                    </li>
+                    <% n = n == 2 ? 1 : 2 %>
+                  <% end %>
+                  </ul>
+                <% end %>
+          <% end %>
           </ul>
         <% end %>
       <% end %>

--- a/lib/templates/default/fulldoc/html/full_list_features.erb
+++ b/lib/templates/default/fulldoc/html/full_list_features.erb
@@ -10,7 +10,7 @@
   <div class="item" style="padding-left: 30px">
     <%= "<a class='toggle'></a>" unless feature.scenarios.empty? %>
     <%= linkify feature, feature.value %>
-    <small><%= feature.location %></small>
+    <small style="display: inline;"><%= feature.total_scenarios %></small>
   </div>
 
   <% n = n == 'odd' ? 'even' : 'odd' %>

--- a/lib/templates/default/fulldoc/html/full_list_tags.erb
+++ b/lib/templates/default/fulldoc/html/full_list_tags.erb
@@ -9,7 +9,7 @@
   <li class="<%= n %>">
     <div class="item" style="padding-left: 30px;">
       <%= linkify tag, tag.value %>
-      <small style="display: inline;"><%= tag.all_scenarios.size %></small>
+      <small style="display: inline;"><%= tag.total_scenarios %></small>
     </div>
   </li>
   <% n = n == 'odd' ? 'even' : 'odd' %>

--- a/lib/templates/default/fulldoc/html/js/cucumber.js
+++ b/lib/templates/default/fulldoc/html/js/cucumber.js
@@ -277,6 +277,15 @@ function displayQualifyingFeaturesAndScenarios(tags) {
 
 }
 
+function updateScenarioCount() {
+    var count = 0;
+    $(".scenario:visible").each(function(index) {
+        count += parseInt($(this).attr("count"))
+    });
+    count_header = " (" + count + ")";
+    document.getElementById("scenario_count").innerHTML = count_header;
+}
+
 function generateCssSelectorFromTags(tagGroups) {
 
     var tagSelectors = [ "" ];

--- a/lib/templates/default/fulldoc/html/setup.rb
+++ b/lib/templates/default/fulldoc/html/setup.rb
@@ -73,7 +73,6 @@ def serialize_feature_directories_recursively(namespaces)
   end
 end
 
-
 # Generate feature list
 # @note this method is called automatically by YARD based on the menus defined in the layout
 def generate_feature_list
@@ -82,11 +81,32 @@ def generate_feature_list
   generate_full_list features_ordered_by_name, :features
 end
 
+# Count scenarios for features
+def record_feature_scenarios(features)
+  count_with_examples = 0
+  features.each do |f|
+    count_with_examples += f.total_scenarios
+  end
+  return count_with_examples
+end
+
+# Count scenarios for tags
+def record_tagged_scenarios(tags)
+  scenario_count = 0
+  count_with_examples = 0
+  tags.each do |t|
+    scenario_count += t.all_scenarios.size
+    count_with_examples += t.total_scenarios
+  end
+end
+
 # Generate tag list
 # @note this method is called automatically by YARD based on the menus defined in the layout
 def generate_tag_list
   tags = Registry.all(:tag)
-  tags_ordered_by_use = Array(tags).sort {|x,y| y.all_scenarios.size <=> x.all_scenarios.size }
+  tags_ordered_by_use = Array(tags).sort {|x,y| y.total_scenarios <=> x.total_scenarios }
+
+  record_tagged_scenarios(tags)
 
   generate_full_list tags_ordered_by_use, :tags
 end
@@ -162,10 +182,12 @@ end
 # When there are is just one feature directory then we want to link to that directory
 #
 def all_features_link
+  features = Registry.all(:feature)
+  count_with_examples = record_feature_scenarios(features)
   if root_feature_directories.length == 0 || root_feature_directories.length > 1
-    linkify YARD::CodeObjects::Cucumber::CUCUMBER_NAMESPACE, "All Features"
+    linkify YARD::CodeObjects::Cucumber::CUCUMBER_NAMESPACE, "All Features (#{count_with_examples})"
   else
-    linkify root_feature_directories.first, "All Features"
+    linkify root_feature_directories.first, "All Features (#{count_with_examples})"
   end
 end
 

--- a/lib/templates/default/tag/html/alpha_table.erb
+++ b/lib/templates/default/tag/html/alpha_table.erb
@@ -14,7 +14,8 @@
               <% objects.each do |obj| %>
                 <li>
                   <% if obj.is_a?(YARD::CodeObjects::Cucumber::Scenario) || obj.is_a?(YARD::CodeObjects::Cucumber::ScenarioOutline) %>
-                    <a href="<%= url_for(obj.feature,"scenario_#{obj.path[(/.+_(\d+)$/),1]}") %>">
+                    <% index = obj.path[(/.+_(\d+)$/),1].to_i - 1 %>
+                    <a href="<%= url_for(obj.feature,"scenario_#{index}") %>">
                  		  <%= h obj.value %>
                  		</a>
                   <% else %>

--- a/lib/yard/code_objects/cucumber/feature.rb
+++ b/lib/yard/code_objects/cucumber/feature.rb
@@ -4,12 +4,13 @@ module YARD::CodeObjects::Cucumber
 
   class Feature < NamespaceObject
     
-    attr_accessor :background, :comments, :description, :keyword, :scenarios, :tags, :value
+    attr_accessor :background, :comments, :description, :keyword, :scenarios, :tags, :value, :total_scenarios
 
     def initialize(namespace,name)
       @comments = ""
       @scenarios = []
       @tags = []
+      @total_scenarios = 0
       super(namespace,name.to_s.strip)
     end
 

--- a/lib/yard/code_objects/cucumber/scenario_outline.rb
+++ b/lib/yard/code_objects/cucumber/scenario_outline.rb
@@ -5,7 +5,7 @@ module YARD::CodeObjects::Cucumber
   class ScenarioOutline < NamespaceObject
 
     attr_accessor :value, :comments, :keyword, :description, :steps, :tags, :feature
-    attr_accessor :scenarios, :examples
+    attr_accessor :scenarios, :examples 
 
     def initialize(namespace,name)
       super(namespace,name.to_s.strip)
@@ -27,11 +27,10 @@ module YARD::CodeObjects::Cucumber
     def examples?
       @examples.find {|example| example.rows }
     end
-    
-    
+
     class Examples
       
-      attr_accessor :name, :line, :keyword, :comments, :rows
+      attr_accessor :name, :line, :keyword, :comments, :rows, :tags, :scenario
       
       # The first row of the rows contains the headers for the table
       def headers

--- a/lib/yard/code_objects/cucumber/tag.rb
+++ b/lib/yard/code_objects/cucumber/tag.rb
@@ -4,16 +4,22 @@ module YARD::CodeObjects::Cucumber
 
   class Tag < NamespaceObject
 
-    attr_accessor :value, :owners
+    attr_accessor :value, :owners, :total_scenarios
     
     def features
       @owners.find_all{|owner| owner.is_a?(Feature) }
     end
     
     def scenarios
-      @owners.find_all{|owner| owner.is_a?(Scenario) || owner.is_a?(ScenarioOutline) }
+      all = @owners.find_all{|owner| owner.is_a?(Scenario) || owner.is_a?(ScenarioOutline) }
+      @owners.each {|owner|
+        if owner.is_a?(ScenarioOutline::Examples) && !all.include?(owner.scenario)
+          all << owner.scenario
+        end
+      }
+      return all
     end
-        
+
     def indirect_scenarios
       @owners.find_all{|owner| owner.is_a?(Feature) }.collect {|feature| feature.scenarios }.flatten
     end
@@ -21,7 +27,7 @@ module YARD::CodeObjects::Cucumber
     def all_scenarios
       scenarios + indirect_scenarios
     end
-    
+
   end
 
 end


### PR DESCRIPTION
Surfaces tags defined at each example table.
Provides scenario counts from feature list, tag list, and tag filters.
Scenario count will not include a scenario outline definition. A scenario from an outline will only be counted for each data row provided in the associated examples table(s).