### PR TITLE
Support step definitions without blocks

### DIFF
--- a/example/scenario.feature
+++ b/example/scenario.feature
@@ -61,3 +61,14 @@ Feature: Displaying Scenarios
   Scenario: Step ending with a match with double-quotes
     When searching the log for the exact match of the message "Entering application."
     When the step definition has HTML escaped characters like: "<>&"
+
+  Scenario: Steps defined with a common block
+    This scenario executes several steps that were all created
+    with a common proc. This is useful when writing a process 
+    that is then aliased for multiple languages. The english 
+    keyword has been used as a constant here as that is a
+    different feature
+
+    When say something
+    When di algo
+    When dis quelquechose

--- a/example/step_definitions/example.step.rb
+++ b/example/step_definitions/example.step.rb
@@ -120,3 +120,25 @@ end
 def a_helper_method
   puts "performs some operation"
 end
+
+#
+# This is a block used in multiple steps 
+#
+saySomething = Proc.new do |something|
+   puts something
+end
+
+#
+# Engligh step say something
+#
+When /^say ([^$]*)$/, saySomething
+
+#
+# Spanish step fo say something
+#
+When /^di ([^$]*)$/, saySomething
+
+#
+# French step fo say something
+#
+When /^dis ([^$]*)$/, saySomething

--- a/lib/yard/handlers/step_definition_handler.rb
+++ b/lib/yard/handlers/step_definition_handler.rb
@@ -49,12 +49,12 @@ class YARD::Handlers::Ruby::StepDefinitionHandler < YARD::Handlers::Ruby::Base
       o.source = statement.source
       o.comments = statement.comments
       o.keyword = statement.method_name.source
-      o.value = statement.parameters.source
-      o.pending = pending_keyword_used?(statement.block)
+      o.value = statement.parameters[0].source
+      o.pending = pending_keyword_used?(statement.block) unless statement.block.nil?
     end
 
     obj = register instance
-    parse_block(statement[2],:owner => obj)
+    parse_block(statement[2],:owner => obj) unless statement.block.nil?
 
   end
 


### PR DESCRIPTION
Added support for handling steps defined with the proc passed as an argument rather than a block