### PR TITLE
Skip building objects when files have absolute paths

### DIFF
--- a/lib/cucumber/city_builder.rb
+++ b/lib/cucumber/city_builder.rb
@@ -49,6 +49,8 @@ module Cucumber
         @namespace = YARD::CodeObjects::Cucumber::CUCUMBER_NAMESPACE
 
         File.dirname(file).split('/').each do |directory|
+          next if directory.empty?
+
           @namespace = @namespace.children.find {|child| child.is_a?(YARD::CodeObjects::Cucumber::FeatureDirectory) && child.name.to_s == directory } ||
             @namespace = YARD::CodeObjects::Cucumber::FeatureDirectory.new(@namespace,directory) {|dir| dir.add_file(directory)}
         end


### PR DESCRIPTION
In case there are defined absolute paths for files in yardoc command, splitting returns an empty string as the first item and  creating a `FeatureDirectory` fails on the lines below with `ArgumentError: invalid empty object name in yard-0.9.16/lib/yard/code_objects/base.rb:190:in new`