### PR TITLE
Fix #94

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 # Documents folder
 doc
 .yardoc
+
+# Ignore local Bundler installations
+/.bundle/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yard-cucumber (3.1.0)
+    yard-cucumber (4.0.0)
       cucumber (>= 2.0, < 4.0)
       gherkin (>= 4.0, < 6.0)
       yard (~> 0.8, >= 0.8.1)

--- a/lib/templates/default/fulldoc/html/setup.rb
+++ b/lib/templates/default/fulldoc/html/setup.rb
@@ -163,7 +163,7 @@ end
 # This method removes the namespace from the root node, generates the class list,
 # and then adds it back into the root node.
 #
-def class_list(root = Registry.root, tree = TreeContext.new)
+def class_list(root = Registry.root, tree = self.class.const_get(:TreeContext).new)
   return super unless root == Registry.root
 
   cucumber_namespace = YARD::CodeObjects::Cucumber::CUCUMBER_NAMESPACE


### PR DESCRIPTION
Includes fix to #94, as well as a slight change to `.gitignore` for local `.bundle` installations and an update to `Gemfile.lock` for the current gem version.

Seems to work on the project repo YARD docs themselves, as well as the project I was working on. I wasn't sure how to test the changes (see #96).

If you want me to bump the gem version and such too let me know; I could really use this released so I can push a gem that depends on it without publishing a fork.